### PR TITLE
fix "is a program, not an importable package" error

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ To create a simple Pinterest client:
 
 ```go
 import(
-    pinterest "github.com/carrot/go-pinterest"
+    "github.com/carrot/go-pinterest"
     // Below imports aren't needed immediately, but you'll want these soon after
 	"github.com/carrot/go-pinterest/controllers"
 	"github.com/carrot/go-pinterest/models"

--- a/pinterest.go
+++ b/pinterest.go
@@ -1,10 +1,11 @@
-package main
+package pinterest
 
 import (
-	"github.com/BrandonRomano/wrecker"
-	"github.com/carrot/go-pinterest/controllers"
 	"net/http"
 	"time"
+
+	"github.com/BrandonRomano/wrecker"
+	"github.com/carrot/go-pinterest/controllers"
 )
 
 // Client is an API client that connects you with the

--- a/pinterest_test.go
+++ b/pinterest_test.go
@@ -1,15 +1,16 @@
-package main_test
+package pinterest_test
 
 import (
+	"net/http"
+	"os"
+	"testing"
+	"time"
+
 	pinterest "github.com/carrot/go-pinterest"
 	"github.com/carrot/go-pinterest/controllers"
 	"github.com/carrot/go-pinterest/models"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
-	"net/http"
-	"os"
-	"testing"
-	"time"
 )
 
 // In order for 'go test' to run this suite, we need to create


### PR DESCRIPTION
This PR fixes import error `'github.com/carrot/go-pinterest' is a program, not an importable package` on go >1.5 (I think)