### PR TITLE
Fix tests

### DIFF
--- a/pinterest_test.go
+++ b/pinterest_test.go
@@ -67,7 +67,6 @@ func (suite *ClientTestSuite) TestNotFoundUserFetch() {
 
 	// Assume there is an error
 	assert.NotEqual(suite.T(), nil, err)
-	assert.Equal(suite.T(), err.Error(), "PinterestError: {\"status_code\":404,\"message\":\"User not found.\"}")
 
 	// Check error type
 	if pinterestError, ok := err.(*models.PinterestError); ok {


### PR DESCRIPTION
The real reason for all these tests failing was an expired access token in configuration in Travis CI -- but also I really should never have been doing an error string check here (the struct was updated recently to also show the rate limit, which made this be a breaking test).